### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,5 +6,5 @@
 The target is to apply gradually all features of F# until to the final point where Domain Driven Design principles are applied. 
 Some metrics will take place and listed here in order to compare the two approaches as we go along. 
 
-In branch [OOP](https://github.com/klimisa/CargoTracker2FSharp/tree/oop) there is a direct port - line by line - of the [Shipping Domain](https://github.com/gtourkas/CargoTracker2/tree/master/Domain) to F#. 
+In branch [phase-0](https://github.com/klimisa/CargoTracker2FSharp/tree/phase-0) there is a direct port - line by line - of the [Shipping Domain](https://github.com/gtourkas/CargoTracker2/tree/master/Domain) to F#. 
 The original test suite runs to ensure the correctness of the port.


### PR DESCRIPTION
Since `oop` is currently equal to `phase-0` and `phase-0` will stay as-is, perhaps we get rid of `oop` branch entirely?

(NOTE: I don't have access to delete the branch if you decide to merge this. You'd have to do it yourself.)